### PR TITLE
Rebrand workspace to team

### DIFF
--- a/resources/task.js
+++ b/resources/task.js
@@ -83,7 +83,7 @@ module.exports = {
         {
           key: 'workspace',
           type: 'string',
-          helpText: 'Workspace for Task',
+          helpText: 'Team for Task',
           dynamic: 'workspace.id.name',
           altersDynamicFields: true,
         },
@@ -103,7 +103,7 @@ module.exports = {
         {
           key: 'workspace',
           type: 'integer',
-          label: 'Workspace',
+          label: 'Team',
           dynamic: 'workspace.id.name',
           altersDynamicFields: true,
           required: true,

--- a/resources/workspace.js
+++ b/resources/workspace.js
@@ -26,12 +26,12 @@ const getWorkspace = (z, bundle) => {
 
 module.exports = {
   key: 'workspace',
-  noun: 'Workspace',
+  noun: 'Team',
 
   list: {
     display: {
-      label: 'New Workspace',
-      description: 'Triggers when a new workspace is added.',
+      label: 'New Team',
+      description: 'Triggers when a new team is added.',
     },
     operation: {
       perform: listWorkspaces,
@@ -40,8 +40,8 @@ module.exports = {
 
   get: {
     display: {
-      label: 'Get Workspace',
-      description: 'Gets a workspace',
+      label: 'Get Team',
+      description: 'Gets a single team from Flow',
     },
     operation: {
       inputFields: [{ key: 'id', required: true }],


### PR DESCRIPTION
Workspaces are still workspaces on the API but we call them teams in the
app, so it makes sense to call them teams on Zapier as well.