### PR TITLE
Switch from JSON.parse to z.JSON.parse

### DIFF
--- a/resources/account.js
+++ b/resources/account.js
@@ -10,7 +10,7 @@ const listAccounts = (z, bundle) => {
         include: 'accounts',
       },
     })
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.accounts);
 };
 

--- a/resources/project.js
+++ b/resources/project.js
@@ -10,7 +10,7 @@ const listProjects = (z, bundle) => {
         include: 'sections',
       },
     })
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.lists);
 };
 
@@ -23,7 +23,7 @@ const getProject = (z, bundle) => {
         workspace_id: bundle.inputData.workspace,
       },
     })
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.list);
 };
 

--- a/resources/task.js
+++ b/resources/task.js
@@ -8,7 +8,7 @@ const getTask = (z, bundle) => {
         organization_id: bundle.authData.orgId,
       },
     })
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.task);
 };
 
@@ -38,7 +38,7 @@ const createTask = (z, bundle) => {
 
   return z
     .request(request)
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.task);
 };
 
@@ -51,7 +51,7 @@ const listTasks = (z, bundle) => {
         ...(bundle.inputData.workspace && { workspace_id: bundle.inputData.workspace }),
       },
     })
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.tasks);
 };
 

--- a/resources/workspace.js
+++ b/resources/workspace.js
@@ -8,7 +8,7 @@ const listWorkspaces = (z, bundle) => {
         organization_id: bundle.authData.orgId,
       },
     })
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.workspaces);
 };
 
@@ -20,7 +20,7 @@ const getWorkspace = (z, bundle) => {
         organization_id: bundle.authData.orgId,
       },
     })
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.workspace);
 };
 

--- a/triggers/section.js
+++ b/triggers/section.js
@@ -10,7 +10,7 @@ const getSections = (z, bundle) => {
         include: 'sections',
       },
     })
-    .then((response) => JSON.parse(response.content))
+    .then((response) => z.JSON.parse(response.content))
     .then((json) => json.sections);
 };
 


### PR DESCRIPTION
Closes [Issue 11](https://github.com/flowapp/zapier-flow/issues/11)

>z.JSON is similar to the JSON built-in like z.JSON.parse('...'), but catches errors and produces nicer tracebacks.