### PR TITLE
Add `order` param to task list

### DIFF
--- a/resources/task.js
+++ b/resources/task.js
@@ -47,6 +47,7 @@ const listTasks = (z, bundle) => {
     .request({
       url: `${FLOW_API_URL}/tasks`,
       params: {
+        order: 'created_at',
         organization_id: bundle.authData.orgId,
         ...(bundle.inputData.workspace && { workspace_id: bundle.inputData.workspace }),
       },

--- a/resources/task.test.js
+++ b/resources/task.test.js
@@ -23,6 +23,7 @@ describe('Task', function () {
     nock('https://api.getflow.com')
       .get('/v2/tasks')
       .query({
+        order: 'created_at',
         organization_id: 1,
       })
       .reply(200, {


### PR DESCRIPTION
Since we are polling for recently created tasks it makes sense to ensure that we are ordering tasks descending by created_at date.

The API does use created_at as the default order but it seems silly to rely on that when we have the power to be explicit.