### PR TITLE
Make Account a hidden trigger

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const includeApiKeyHeader = (request, z, bundle) => {
 const Task = require('./resources/task');
 const Project = require('./resources/project');
 const Workspace = require('./resources/workspace');
-const Account = require('./resources/account');
+const Account = require('./triggers/account');
 const Section = require('./triggers/section');
 
 // Now we can roll up all our behavios in an App.
@@ -32,12 +32,12 @@ const App = {
     [Task.key]: Task,
     [Project.key]: Project,
     [Workspace.key]: Workspace,
-    [Account.key]: Account,
   },
 
   // If you want your trigger to show up, you better include it here!
   triggers: {
     [Section.key]: Section,
+    [Account.key]: Account,
   },
 
   // If you want your searches to show up, you better include it here!

--- a/triggers/account.js
+++ b/triggers/account.js
@@ -1,6 +1,6 @@
 const { FLOW_API_URL } = require('../utils/constants');
 
-const listAccounts = (z, bundle) => {
+const getAccounts = (z, bundle) => {
   return z
     .request({
       url: `${FLOW_API_URL}/memberships`,
@@ -18,13 +18,12 @@ module.exports = {
   key: 'account',
   noun: 'Account',
 
-  list: {
-    display: {
-      label: 'New Account',
-      description: 'Triggers when a new account is added.',
-    },
-    operation: {
-      perform: listAccounts,
-    },
+  display: {
+    label: 'List of Accounts',
+    description: 'This hidden trigger gets a list of accounts in a Team.',
+    hidden: true,
+  },
+  operation: {
+    perform: getAccounts,
   },
 };


### PR DESCRIPTION
Since this isn’t a relaible way to tell when new accounts have been added to Flow, we don’t want to allow our users to poll this endpoint for "New Account created" logic, but we still need it in order to populate the task creation assignee field.