### PR TITLE
Don't exposed the completed tasks section in the task creation action

### DIFF
--- a/triggers/section.js
+++ b/triggers/section.js
@@ -1,5 +1,18 @@
 const { FLOW_API_URL } = require('../utils/constants');
 
+/*
+ * Sections are used for the task creation action and you cannot create a task in the designated completed section; the API will return an error.
+ * This method returns an array of valid sections dervied from the respone.
+ *
+ * @param {Object} json
+ * @return {Array} sections
+*/
+function filterOutCompletedTaskSection(json) {
+  return json.sections.filter((section) => {
+    return section.id !== json.list.completed_section_id;
+  });
+}
+
 const getSections = (z, bundle) => {
   return z
     .request({
@@ -11,7 +24,7 @@ const getSections = (z, bundle) => {
       },
     })
     .then((response) => z.JSON.parse(response.content))
-    .then((json) => json.sections);
+    .then((json) => filterOutCompletedTaskSection(json));
 };
 
 module.exports = {

--- a/triggers/section.test.js
+++ b/triggers/section.test.js
@@ -19,6 +19,7 @@ describe('Section', function () {
         list: {
           id: 100,
           name: 'I am a list',
+          completed_section_id: 95,
         },
         sections: [{
           id: 7,
@@ -27,6 +28,10 @@ describe('Section', function () {
         {
           id: 22,
           name: 'I am another section',
+        },
+        {
+          id: 95,
+          name: 'I am the done section',
         },
         {
           id: 45,
@@ -53,6 +58,15 @@ describe('Section', function () {
         expect(results[0].id).toEqual(7);
         expect(results[1].id).toEqual(22);
         expect(results[2].id).toEqual(45);
+        done();
+      });
+    });
+
+    it('should filter out the done section', function (done) {
+      appTester(App.triggers.section.operation.perform, bundle).then(function (results) {
+        expect(results.find((item) => {
+          return item.id === 95;
+        })).toEqual(undefined);
         done();
       });
     });


### PR DESCRIPTION
The API does not allow you to create tasks in this section so we
shouldn't show it as an option.

Fixes https://github.com/flowapp/zapier-flow/issues/28