### PR TITLE
Rename 'updatedAfter' to 'updated_after'

### DIFF
--- a/resources/task.js
+++ b/resources/task.js
@@ -144,7 +144,7 @@ const listRecentlyUpdatedTasks = (z, bundle) => {
   if (!bundle.meta || !bundle.meta.isLoadingSample) {
     let updatedAfter = new Date();
     updatedAfter.setHours(updatedAfter.getHours() - 1);
-    params.updatedAfter = updatedAfter;
+    params.updated_after = updatedAfter.toISOString();
   }
 
   return z

--- a/resources/task.test.js
+++ b/resources/task.test.js
@@ -23,7 +23,21 @@ describe('Task', function () {
     // Mock request for getting a list of tasks
     nock(FLOW_API_URL)
       .get('/tasks')
-      .query(true)
+      .query((queryObject) => {
+        if (!queryObject.updated_after) {
+          return false;
+        }
+
+        if (!queryObject.organization_id) {
+          return false;
+        }
+
+        if (!queryObject.order) {
+          return false;
+        }
+
+        return true;
+      })
       .reply(200, {
         tasks: [{
           id: 37,


### PR DESCRIPTION
What a shameful bug, I don't know how I managed this. I must have tested and then refactored a bit before pull requesting and then didn't re-test.

I added a better check to our tests so that similar query dumbness doesn't happen in the future here.