### PR TITLE
Rename project to list in code

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const includeApiKeyHeader = (request, z, bundle) => {
 };
 
 const Task = require('./resources/task');
-const Project = require('./resources/project');
+const List = require('./resources/list');
 const Workspace = require('./resources/workspace');
 const Account = require('./triggers/account');
 const Section = require('./triggers/section');
@@ -30,7 +30,7 @@ const App = {
   // If you want your resource to show up, you better include it here!
   resources: {
     [Task.key]: Task,
-    [Project.key]: Project,
+    [List.key]: List,
     [Workspace.key]: Workspace,
   },
 

--- a/resources/list.js
+++ b/resources/list.js
@@ -1,6 +1,6 @@
 const { FLOW_API_URL } = require('../utils/constants');
 
-const listProjects = (z, bundle) => {
+const listLists = (z, bundle) => {
   return z
     .request({
       url: `${FLOW_API_URL}/lists`,
@@ -14,7 +14,7 @@ const listProjects = (z, bundle) => {
     .then((json) => json.lists);
 };
 
-const getProject = (z, bundle) => {
+const getList = (z, bundle) => {
   return z
     .request({
       url: `${FLOW_API_URL}/lists/${bundle.inputData.id}`,
@@ -28,7 +28,7 @@ const getProject = (z, bundle) => {
 };
 
 module.exports = {
-  key: 'project',
+  key: 'list',
   noun: 'Project',
 
   list: {
@@ -46,7 +46,7 @@ module.exports = {
           altersDynamicFields: true,
         },
       ],
-      perform: listProjects,
+      perform: listLists,
       sample: {
         id: 1,
         name: 'Test project A',
@@ -77,7 +77,7 @@ module.exports = {
     },
     operation: {
       inputFields: [{ key: 'id', required: true }],
-      perform: getProject,
+      perform: getList,
     },
   },
 };

--- a/resources/list.test.js
+++ b/resources/list.test.js
@@ -4,10 +4,10 @@ const appTester = zapier.createAppTester(App);
 const nock = require('nock');
 const { FLOW_API_URL } = require('../utils/constants');
 
-describe('Project', function () {
+describe('List', function () {
   let bundle;
   beforeEach(function () {
-    // Mock request for getting a single project
+    // Mock request for getting a single list
     nock(FLOW_API_URL)
       .get('/lists/3')
       .query({
@@ -21,7 +21,7 @@ describe('Project', function () {
         },
       });
 
-    // Mock request for getting a list of projects
+    // Mock request for getting a list of lists
     nock(FLOW_API_URL)
       .get('/lists')
       .query({
@@ -60,10 +60,10 @@ describe('Project', function () {
   });
 
   describe('Get', function () {
-    it('should get a single project', function (done) {
+    it('should get a single list', function (done) {
       bundle.inputData.id = 3;
 
-      appTester(App.resources.project.get.operation.perform, bundle).then(function (results) {
+      appTester(App.resources.list.get.operation.perform, bundle).then(function (results) {
         expect(results.id).toEqual(3);
         expect(results.name).toEqual('I am a list');
         done();
@@ -72,8 +72,8 @@ describe('Project', function () {
   });
 
   describe('List', function () {
-    it('should load a list of projects', function (done) {
-      appTester(App.resources.project.list.operation.perform, bundle).then(function (results) {
+    it('should load a list of lists', function (done) {
+      appTester(App.resources.list.list.operation.perform, bundle).then(function (results) {
         expect(results.length).toEqual(4);
         expect(results[0].id).toEqual(1);
         expect(results[1].id).toEqual(2);

--- a/resources/task.js
+++ b/resources/task.js
@@ -245,7 +245,7 @@ module.exports = {
           key: 'list',
           type: 'integer',
           label: 'Project',
-          dynamic: 'project.id.name',
+          dynamic: 'list.id.name',
           helpText:
             'Choose a project for your task to be created in. Projects are grouped under Teams, so if you can’t find the project you want, ensure the correct team is selected.',
           altersDynamicFields: true,


### PR DESCRIPTION
Still called a project to our users but rename to list in code to match the API's naming