### PR TITLE
Switch from updated_after to created_after when polling for new tasks

### DIFF
--- a/resources/task.js
+++ b/resources/task.js
@@ -139,12 +139,12 @@ const listRecentlyUpdatedTasks = (z, bundle) => {
     ...(bundle.inputData.workspace && { workspace_id: bundle.inputData.workspace }),
   };
 
-  // We only want to pass updated_after if it is running for real,
+  // We only want to pass created_after if it is running for real,
   // otherwise potentially sample data will not be populated if a user hasn't recently updated any tasks.
   if (!bundle.meta || !bundle.meta.isLoadingSample) {
-    let updatedAfter = new Date();
-    updatedAfter.setHours(updatedAfter.getHours() - 1);
-    params.updated_after = updatedAfter.toISOString();
+    let createdAfter = new Date();
+    createdAfter.setHours(createdAfter.getHours() - 1);
+    params.created_after = createdAfter.toISOString();
   }
 
   return z

--- a/resources/task.js
+++ b/resources/task.js
@@ -132,7 +132,7 @@ const createTask = (z, bundle) => {
     .then((json) => json.task);
 };
 
-const listRecentlyUpdatedTasks = (z, bundle) => {
+const listRecentlyCreatedTasks = (z, bundle) => {
   let params = {
     order: 'created_at',
     organization_id: bundle.authData.orgId,
@@ -140,7 +140,7 @@ const listRecentlyUpdatedTasks = (z, bundle) => {
   };
 
   // We only want to pass created_after if it is running for real,
-  // otherwise potentially sample data will not be populated if a user hasn't recently updated any tasks.
+  // otherwise potentially sample data will not be populated if a user hasn't recently created any tasks.
   if (!bundle.meta || !bundle.meta.isLoadingSample) {
     let createdAfter = new Date();
     createdAfter.setHours(createdAfter.getHours() - 1);
@@ -191,7 +191,7 @@ module.exports = {
         },
       ],
       outputFields: TaskOutputFields,
-      perform: listRecentlyUpdatedTasks,
+      perform: listRecentlyCreatedTasks,
       sample: {
         id: 1,
         name: 'Test task A',

--- a/resources/task.test.js
+++ b/resources/task.test.js
@@ -24,7 +24,7 @@ describe('Task', function () {
     nock(FLOW_API_URL)
       .get('/tasks')
       .query((queryObject) => {
-        if (!queryObject.updated_after) {
+        if (!queryObject.created_after) {
           return false;
         }
 


### PR DESCRIPTION
If someone updates an old task it will resurface to the top again so we should use created_after to make sure we only get newly created tasks.

I'm really flying fast and loose here sorry 😕 need to slow down.