### PR TITLE
Refactoring

### DIFF
--- a/resources/list.js
+++ b/resources/list.js
@@ -1,6 +1,10 @@
 const { FLOW_API_URL } = require('../utils/constants');
 
-const listLists = (z, bundle) => {
+/*
+ * Fetch all lists in a workspace that the user has access to,
+ * providing they are not soft-deleted or archived
+*/
+const getListsInWorkspace = (z, bundle) => {
   return z
     .request({
       url: `${FLOW_API_URL}/lists`,
@@ -46,7 +50,7 @@ module.exports = {
           altersDynamicFields: true,
         },
       ],
-      perform: listLists,
+      perform: getListsInWorkspace,
       sample: {
         id: 1,
         name: 'Test project A',

--- a/resources/list.js
+++ b/resources/list.js
@@ -1,6 +1,37 @@
 const { FLOW_API_URL } = require('../utils/constants');
 
 /*
+  * Method to convert API list response to trim down unneeded values
+  * When Zapier populates the action part of the form it grabs all items from the list response
+  * without any discrimination. Many of the items are poorly labelled and not likely to be needed for any integration.
+  *
+  * In order to help clean up the noise, this method cherry-picks the values that seem important to expose to Zapier.
+  *
+  * @param {Object} List
+  * @return {Object} List
+*/
+function parseList(list) {
+  return {
+    id: list.id,
+    name: list.name,
+    created_at: list.created_at,
+    updated_at: list.updated_at,
+    completed_section_id: list.completed_section_id,
+    completed_tasks_count: list.completed_tasks_count,
+    default_section_id: list.default_section_id,
+    default_view: list.default_view,
+    ends_on: list.ends_on,
+    group_id: list.group_id,
+    include_weekends: list.include_weekends,
+    invite_only: list.invite_only,
+    starts_on: list.starts_on,
+    subscriber_ids: list.subscriber_ids,
+    tasks_count: list.tasks_count,
+    workspace_id: list.workspace_id,
+  };
+}
+
+/*
  * Fetch all lists in a workspace that the user has access to,
  * providing they are not soft-deleted or archived
 */
@@ -15,7 +46,7 @@ const getListsInWorkspace = (z, bundle) => {
       },
     })
     .then((response) => z.JSON.parse(response.content))
-    .then((json) => json.lists);
+    .then((json) => json.lists.map(parseList));
 };
 
 const getList = (z, bundle) => {
@@ -28,7 +59,7 @@ const getList = (z, bundle) => {
       },
     })
     .then((response) => z.JSON.parse(response.content))
-    .then((json) => json.list);
+    .then((json) => parseList(json.list));
 };
 
 module.exports = {

--- a/resources/list.js
+++ b/resources/list.js
@@ -1,5 +1,27 @@
 const { FLOW_API_URL } = require('../utils/constants');
 
+const ListOutputFields = [
+  {
+    key: 'workspace_id',
+    label: 'Team ID',
+  },
+
+  {
+    key: 'default_view',
+    label: 'Default View (either “row” or “column”)',
+  },
+
+  {
+    key: 'tasks_count',
+    label: 'Total Task Count (including completed)',
+  },
+
+  {
+    key: 'completed_tasks_count',
+    label: 'Completed Task Count',
+  },
+];
+
 /*
   * Method to convert API list response to trim down unneeded values
   * When Zapier populates the action part of the form it grabs all items from the list response
@@ -81,6 +103,7 @@ module.exports = {
           altersDynamicFields: true,
         },
       ],
+      outputFields: ListOutputFields,
       perform: getListsInWorkspace,
       sample: {
         id: 1,
@@ -112,6 +135,7 @@ module.exports = {
     },
     operation: {
       inputFields: [{ key: 'id', required: true }],
+      outputFields: ListOutputFields,
       perform: getList,
     },
   },

--- a/resources/task.js
+++ b/resources/task.js
@@ -132,7 +132,11 @@ const createTask = (z, bundle) => {
     .then((json) => json.task);
 };
 
-const listRecentlyCreatedTasks = (z, bundle) => {
+/*
+ * Get all tasks that have been created in the last hour in an organization.
+ * workspace can also optionally be specified for a more granular response.
+*/
+const getRecentlyCreatedTasks = (z, bundle) => {
   let params = {
     order: 'created_at',
     organization_id: bundle.authData.orgId,
@@ -191,7 +195,7 @@ module.exports = {
         },
       ],
       outputFields: TaskOutputFields,
-      perform: listRecentlyCreatedTasks,
+      perform: getRecentlyCreatedTasks,
       sample: {
         id: 1,
         name: 'Test task A',

--- a/resources/task.js
+++ b/resources/task.js
@@ -2,15 +2,6 @@ const { FLOW_API_URL } = require('../utils/constants');
 
 const TaskOutputFields = [
   {
-    key: 'id',
-    label: 'Task ID',
-  },
-  {
-    key: 'name',
-    label: 'Task Name',
-  },
-
-  {
     key: 'workspace_id',
     label: 'Team ID',
   },
@@ -21,43 +12,28 @@ const TaskOutputFields = [
   },
 
   {
-    key: 'section_id',
-    label: 'Section ID',
-  },
-
-  {
     key: 'account_id',
-    label: 'Task Creater ID',
+    label: 'Creater ID',
   },
 
   {
     key: 'owner_id',
-    label: 'Task Assignee ID',
+    label: 'Assignee ID',
   },
 
   {
     key: 'due_on',
-    label: 'Task Due Date',
+    label: 'Due Date',
   },
 
   {
     key: 'starts_on',
-    label: 'Task Start Date',
-  },
-
-  {
-    key: 'created_at',
-    label: 'Task Created At',
+    label: 'Start Date',
   },
 
   {
     key: 'updated_at',
-    label: 'Task Last Updated At',
-  },
-
-  {
-    key: 'tags',
-    label: 'Task Tags',
+    label: 'Last Updated At',
   },
 ];
 

--- a/resources/workspace.js
+++ b/resources/workspace.js
@@ -1,6 +1,8 @@
 const { FLOW_API_URL } = require('../utils/constants');
-
-const listWorkspaces = (z, bundle) => {
+/*
+ * Get all workspaces that the current user is a member of
+*/
+const getWorkspaces = (z, bundle) => {
   return z
     .request({
       url: `${FLOW_API_URL}/workspaces`,
@@ -34,7 +36,7 @@ module.exports = {
       description: 'Triggers when a new team is added.',
     },
     operation: {
-      perform: listWorkspaces,
+      perform: getWorkspaces,
       sample: {
         id: 1,
         name: 'Test team A',

--- a/resources/workspace.js
+++ b/resources/workspace.js
@@ -1,4 +1,29 @@
 const { FLOW_API_URL } = require('../utils/constants');
+
+/*
+  * Method to convert API workspace response to trim down unneeded values
+  * When Zapier populates the action part of the form it grabs all items from the workspace response
+  * without any discrimination. Many of the items are poorly labelled and not likely to be needed for any integration.
+  *
+  * In order to help clean up the noise, this method cherry-picks the values that seem important to expose to Zapier.
+  *
+  * @param {Object} Workspace
+  * @return {Object} Workspace
+*/
+function parseWorkspace(workspace) {
+  return {
+    id: workspace.id,
+    name: workspace.name,
+    created_at: workspace.created_at,
+    updated_at: workspace.updated_at,
+    default: workspace.default,
+    locked: workspace.locked,
+    manually_clear_completed_tasks: workspace.manually_clear_completed_tasks,
+    members_count: workspace.members_count,
+    organization_id: workspace.organization_id,
+  };
+}
+
 /*
  * Get all workspaces that the current user is a member of
 */
@@ -12,7 +37,7 @@ const getWorkspaces = (z, bundle) => {
       },
     })
     .then((response) => z.JSON.parse(response.content))
-    .then((json) => json.workspaces);
+    .then((json) => json.workspaces.map(parseWorkspace));
 };
 
 const getWorkspace = (z, bundle) => {
@@ -24,7 +49,7 @@ const getWorkspace = (z, bundle) => {
       },
     })
     .then((response) => z.JSON.parse(response.content))
-    .then((json) => json.workspace);
+    .then((json) => parseWorkspace(json.workspace));
 };
 
 module.exports = {
@@ -44,7 +69,7 @@ module.exports = {
         default: false,
         locked: true,
         manually_clear_completed_tasks: false,
-        members_cound: 0,
+        members_count: 0,
         organization_id: 1,
       },
     },

--- a/resources/workspace.js
+++ b/resources/workspace.js
@@ -59,7 +59,8 @@ module.exports = {
   list: {
     display: {
       label: 'New Team',
-      description: 'Triggers when a new team is added.',
+      description: 'This hidden trigger is used to populate workspace dropdowns.',
+      hidden: true,
     },
     operation: {
       perform: getWorkspaces,

--- a/resources/workspace.js
+++ b/resources/workspace.js
@@ -8,6 +8,7 @@ const getWorkspaces = (z, bundle) => {
       url: `${FLOW_API_URL}/workspaces`,
       params: {
         organization_id: bundle.authData.orgId,
+        view: 'member',
       },
     })
     .then((response) => z.JSON.parse(response.content))

--- a/resources/workspace.test.js
+++ b/resources/workspace.test.js
@@ -25,6 +25,7 @@ describe('Workspace', function () {
       .get('/workspaces')
       .query({
         organization_id: 1,
+        view: 'member',
       })
       .reply(200, {
         workspaces: [{

--- a/triggers/account.js
+++ b/triggers/account.js
@@ -1,5 +1,8 @@
 const { FLOW_API_URL } = require('../utils/constants');
 
+/*
+ * Get a list of all accounts in a  workspace via the memberships endpoint
+*/
 const getAccounts = (z, bundle) => {
   return z
     .request({

--- a/triggers/section.js
+++ b/triggers/section.js
@@ -13,6 +13,11 @@ function filterOutCompletedTaskSection(json) {
   });
 }
 
+/*
+ * Get all sections within a list, filtering out the 'done' section as
+ * we are using this for auto-complete on task creation and we do not want to create tasks
+ * in the done section.
+*/
 const getSections = (z, bundle) => {
   return z
     .request({


### PR DESCRIPTION
See individual commits but most of this is just trying to clean things up so  that we expose more readable values to our users.

One notable behaviour change is this: https://github.com/flowapp/zapier-flow/commit/5ba19b9e8c24a7729f1df6c7765e4235d3de591a

Previously we got ALL workspaces that a user had permission to join, but that will cause api errors if the user chooses a workspace they are not a member of for things like creating a task or list, (they have permission to join but no other read/write unless they actually join it) so we had to change this request. However, this means the "new workspace created" trigger wouldn't work as expected so I made it hidden for now.

----

@josiahwiebe how do you feel about your zapier knowledge? I'm kind of frustrated by the documentation. Having never used zapier before some of it is probably lack of experience so I'm hoping you might have seen this stuff before.

Here's a few things that are bothering me:

1. This workspace change. I would like to make a _new_ trigger for "workspace created" using the other endpoint (See my note above) so that we can still have "new workspace created" but it seems like you can only define one `list` and one `create` per resource, so if I wanted to do that I'd have to make some kind of second `allWorkspaces.js` file? I can't define any other methods?

2. Similarly if I wanted to make a new "task is completed" trigger, something I thought might be nice to add for our launch, tasks already has a `list` defined so do I need to make a new `completedTask.js` file? This seems so odd to me, it's still a task resource, just a slightly different trigger. But maybe that is how it is meant to be used, I just find reading the documentation doesn't always feel super clear.

3. I mentioned this in another PR but when the API returns `list_id` on a task I'd love to expose the corresponding project name. We have a list resource so I thought I could define a `dynamic` key in `outputFields` for the task similar to how we do for `inputFields` but it doesn't work. I reached out to Zapier support with what I was trying to do and they told me that  `dynamic` was not supported on `outputFields` but didn't offer any other solution.  I may have to give up on this one.

------

I feel like I am missing some secret zapier-fu and I keep scrolling through the developer documentation and feeling like I am some how not grokking. 
