### PR TITLE
Set up hydrators

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const Workspace = require('./resources/workspace');
 const Account = require('./triggers/account');
 const Section = require('./triggers/section');
 const CompletedTask = require('./triggers/completedTask');
+const hydrators = require('./utils/hydrators');
 
 // Now we can roll up all our behavios in an App.
 const App = {
@@ -47,6 +48,8 @@ const App = {
 
   // If you want your creates to show up, you better include it here!
   creates: {},
+
+  hydrators,
 };
 
 // Finally, export the app.

--- a/resources/task.js
+++ b/resources/task.js
@@ -1,5 +1,5 @@
 const { FLOW_API_URL } = require('../utils/constants');
-const { TaskOutputFields, parseTask, getTask, generateTaskSample } = require('../utils/sharedTaskResources');
+const { TaskOutputFields, parseTask, getTask, generateTaskSample, setupTaskDehydrators } = require('../utils/sharedTaskResources');
 
 const createTask = (z, bundle) => {
   const request = {
@@ -56,6 +56,10 @@ const getRecentlyCreatedTasks = (z, bundle) => {
       params,
     })
     .then((response) => z.JSON.parse(response.content))
+    .then((json) => {
+      json.tasks = json.tasks.map((task) => setupTaskDehydrators(z, task));
+      return json;
+    })
     .then((json) => json.tasks.map(parseTask));
 };
 

--- a/triggers/completedTask.js
+++ b/triggers/completedTask.js
@@ -1,5 +1,5 @@
 const { FLOW_API_URL } = require('../utils/constants');
-const { TaskOutputFields, parseTask, generateTaskSample } = require('../utils/sharedTaskResources');
+const { TaskOutputFields, parseTask, generateTaskSample, setupTaskDehydrators } = require('../utils/sharedTaskResources');
 
 /*
  * Get all tasks that have been completed in the last hour in an organization.
@@ -27,6 +27,10 @@ const getRecentlyCompletedTasks = (z, bundle) => {
       params,
     })
     .then((response) => z.JSON.parse(response.content))
+    .then((json) => {
+      json.tasks = json.tasks.map((task) => setupTaskDehydrators(z, task));
+      return json;
+    })
     .then((json) => json.tasks.map(parseTask));
 };
 

--- a/utils/hydrators.js
+++ b/utils/hydrators.js
@@ -1,0 +1,105 @@
+const { FLOW_API_URL } = require('./constants');
+
+const getListName = function (z, bundle) {
+  return z.request({
+    url: `${FLOW_API_URL}/lists/${bundle.inputData.id}`,
+    params: {
+      organization_id: bundle.authData.orgId,
+      workspace_id: bundle.inputData.workspace_id,
+      include: 'sections',
+    },
+  })
+    .then((response) => z.JSON.parse(response.content))
+    .then((json) => (json.list && json.list.name) || '');
+};
+
+const getSectionName = function (z, bundle) {
+  return z.request({
+    url: `${FLOW_API_URL}/lists/${bundle.inputData.list_id}`,
+    params: {
+      organization_id: bundle.authData.orgId,
+      workspace_id: bundle.inputData.workspace_id,
+      include: 'sections',
+    },
+  })
+    .then((response) => z.JSON.parse(response.content))
+    .then((json) => {
+      let sectionName = '';
+      (json.sections || []).find((section) => {
+        if (section.id === bundle.inputData.id) {
+          sectionName = section.name;
+          return true;
+        }
+
+        return false;
+      });
+
+      return sectionName;
+    });
+};
+
+const getAccountName = function (z, bundle) {
+  return z.request({
+    url: `${FLOW_API_URL}/memberships`,
+    params: {
+      organization_id: bundle.authData.orgId,
+      workspace_id: bundle.inputData.workspace_id,
+      include: 'accounts',
+    },
+  })
+    .then((response) => z.JSON.parse(response.content))
+    .then((json) => {
+      let accountName = '';
+      (json.accounts || []).find((account) => {
+        if (account.id === bundle.inputData.id) {
+          accountName = account.name;
+          return true;
+        }
+
+        return false;
+      });
+
+      return accountName;
+    });
+};
+
+const getAccountNames = function (z, bundle) {
+  return z.request({
+    url: `${FLOW_API_URL}/memberships`,
+    params: {
+      organization_id: bundle.authData.orgId,
+      workspace_id: bundle.inputData.workspace_id,
+      include: 'accounts',
+    },
+  })
+    .then((response) => z.JSON.parse(response.content))
+    .then((json) => {
+      let accountNames = [];
+      (json.accounts || []).forEach((account) => {
+        if (bundle.inputData.ids.includes(account.id)) {
+          accountNames.push(account.name);
+        }
+      });
+
+      return accountNames;
+    });
+};
+
+const getWorkspaceName = function (z, bundle) {
+  return z.request({
+    url: `${FLOW_API_URL}/workspaces/${bundle.inputData.id}`,
+    params: {
+      organization_id: bundle.authData.orgId,
+    },
+  })
+    .then((response) => z.JSON.parse(response.content))
+    .then((json) => (json.workspace && json.workspace.name) || '');
+};
+
+module.exports = {
+  getListName,
+  getWorkspaceName,
+  getSectionName,
+  getAccountName,
+  getAccountNames,
+};

--- a/utils/hydrators.js
+++ b/utils/hydrators.js
@@ -24,17 +24,11 @@ const getSectionName = function (z, bundle) {
   })
     .then((response) => z.JSON.parse(response.content))
     .then((json) => {
-      let sectionName = '';
-      (json.sections || []).find((section) => {
-        if (section.id === bundle.inputData.id) {
-          sectionName = section.name;
-          return true;
-        }
-
-        return false;
+      let section = (json.sections || []).find((item) => {
+        return item.id === bundle.inputData.id;
       });
 
-      return sectionName;
+      return section ? section.name : '';
     });
 };
 
@@ -49,17 +43,11 @@ const getAccountName = function (z, bundle) {
   })
     .then((response) => z.JSON.parse(response.content))
     .then((json) => {
-      let accountName = '';
-      (json.accounts || []).find((account) => {
-        if (account.id === bundle.inputData.id) {
-          accountName = account.name;
-          return true;
-        }
-
-        return false;
+      let account = (json.accounts || []).find((item) => {
+        return item.id === bundle.inputData.id;
       });
 
-      return accountName;
+      return account ? account.name : '';
     });
 };
 

--- a/utils/hydrators.test.js
+++ b/utils/hydrators.test.js
@@ -1,0 +1,204 @@
+const zapier = require('zapier-platform-core');
+const App = require('../index');
+const appTester = zapier.createAppTester(App);
+const nock = require('nock');
+const { FLOW_API_URL } = require('../utils/constants');
+
+describe('Hydrators', function () {
+  let bundle;
+  beforeEach(function () {
+    bundle = {
+      authData: {
+        accessToken: 'fakeTestAccessToken',
+        orgId: 1,
+      },
+    };
+  });
+
+  describe('getListName', function () {
+    beforeEach(function () {
+      bundle.inputData = {
+        workspace_id: 1,
+        id: 50,
+      };
+
+      nock(FLOW_API_URL)
+        .get('/lists/50')
+        .query({
+          organization_id: 1,
+          workspace_id: 1,
+          include: 'sections',
+        })
+        .reply(200, {
+          list: {
+            id: 3,
+            name: 'I am a list',
+          },
+        });
+    });
+
+    it('should return a list name', function (done) {
+      appTester(App.hydrators.getListName, bundle).then(function (result) {
+        expect(result).toEqual('I am a list');
+        done();
+      });
+    });
+  });
+
+  describe('getSectionName', function () {
+    beforeEach(function () {
+      bundle.inputData = {
+        workspace_id: 1,
+        list_id: 50,
+        id: 107,
+      };
+
+      nock(FLOW_API_URL)
+        .get('/lists/50')
+        .query({
+          organization_id: 1,
+          workspace_id: 1,
+          include: 'sections',
+        })
+        .reply(200, {
+          list: {
+            id: 3,
+            name: 'I am a list',
+          },
+
+          sections: [
+            {
+              id: 88,
+              name: 'not the section you are looking for',
+            },
+            {
+              id: 107,
+              name: 'I am a section',
+            },
+            {
+              id: 67,
+              name: 'if this is what you are seeing, the test failed',
+            },
+          ],
+        });
+    });
+
+    it('should return a section name', function (done) {
+      appTester(App.hydrators.getSectionName, bundle).then(function (result) {
+        expect(result).toEqual('I am a section');
+        done();
+      });
+    });
+  });
+
+  describe('getAccountName', function () {
+    beforeEach(function () {
+      bundle.inputData = {
+        workspace_id: 1,
+        id: 42,
+      };
+
+      nock(FLOW_API_URL)
+        .get('/memberships')
+        .query({
+          organization_id: 1,
+          workspace_id: 1,
+          include: 'accounts',
+        })
+        .reply(200, {
+          memberships: [],
+
+          accounts: [
+            {
+              id: 42,
+              name: 'Jon Snow',
+            },
+            {
+              id: 11,
+              name: 'Arya Stark',
+            },
+            {
+              id: 13,
+              name: 'Sansa Stark',
+            },
+          ],
+        });
+    });
+
+    it('should return an account name', function (done) {
+      appTester(App.hydrators.getAccountName, bundle).then(function (result) {
+        expect(result).toEqual('Jon Snow');
+        done();
+      });
+    });
+  });
+
+  describe('getAccountNames', function () {
+    beforeEach(function () {
+      bundle.inputData = {
+        workspace_id: 1,
+        ids: [42, 13],
+      };
+
+      nock(FLOW_API_URL)
+        .get('/memberships')
+        .query({
+          organization_id: 1,
+          workspace_id: 1,
+          include: 'accounts',
+        })
+        .reply(200, {
+          memberships: [],
+
+          accounts: [
+            {
+              id: 42,
+              name: 'Jon Snow',
+            },
+            {
+              id: 11,
+              name: 'Arya Stark',
+            },
+            {
+              id: 13,
+              name: 'Sansa Stark',
+            },
+          ],
+        });
+    });
+
+    it('should return a list of accont names', function (done) {
+      appTester(App.hydrators.getAccountNames, bundle).then(function (result) {
+        expect(result).toEqual(['Jon Snow', 'Sansa Stark']);
+        done();
+      });
+    });
+  });
+
+  describe('getWorkspaceName', function () {
+    beforeEach(function () {
+      bundle.inputData = {
+        id: 1,
+      };
+
+      nock(FLOW_API_URL)
+        .get('/workspaces/1')
+        .query({
+          organization_id: 1,
+        })
+        .reply(200, {
+          workspace: {
+            id: 3,
+            name: 'I am a workspace',
+          },
+        });
+    });
+
+    it('should return a workspace name', function (done) {
+      appTester(App.hydrators.getWorkspaceName, bundle).then(function (result) {
+        expect(result).toEqual('I am a workspace');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Populate values like List Name, Workspace Name, and Section Name, by doing additional API requests. Makes things a bit more user friendly!

With z.dehydrate, zapier only requests what is actually being used.

Thanks @josiahwiebe for pointing me in the right direction!