### PR TITLE
Add Accept header to auth test

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -3,6 +3,9 @@ const { FLOW_API_URL } = require('./utils/constants');
 const testAuth = (z) => {
   const promise = z.request({
     url: `${FLOW_API_URL}/tasks`,
+    headers: {
+      Accept: 'application/vnd.flow.v2+json',
+    },
   });
 
   return promise.then((response) => {


### PR DESCRIPTION
API is replying with a 200 for invalid tokens but if you set the request header it properly returns a 401.

I think this used to work with the old code so I don't know what happened on the API side or the zapier side or what the heck, but the easiest solution is to fix it like this...